### PR TITLE
fix(web): resolve vue-tsc errors in allocation form and contractor test

### DIFF
--- a/src/domains/expense/components/ExpenseAllocationFormModal.vue
+++ b/src/domains/expense/components/ExpenseAllocationFormModal.vue
@@ -213,7 +213,7 @@ const onSubmit = async () => {
               <Label>{{ dimensionLabel(dim) }}</Label>
               <Select
                 :model-value="row.dimensionSelections[dim.dimensionType] ?? NONE_DIMENSION"
-                @update:model-value="row.dimensionSelections[dim.dimensionType] = $event"
+                @update:model-value="row.dimensionSelections[dim.dimensionType] = ($event as string) ?? NONE_DIMENSION"
               >
                 <SelectTrigger>
                   <SelectValue :placeholder="t('expense.allocation.form.dimensionPlaceholder')" />

--- a/src/domains/shared/composables/mutationInvalidation.test.ts
+++ b/src/domains/shared/composables/mutationInvalidation.test.ts
@@ -112,7 +112,7 @@ describe('CRUD mutation invalidation', () => {
     const { result, queryClient } = mountComposable(() => useUpdateContractor())
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-    await result.mutateAsync({ id: 'contractor-1', data: {} })
+    await result.mutateAsync({ id: 'contractor-1', data: {} as never })
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: contractorKeys.lists() })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: contractorKeys.detail('contractor-1') })


### PR DESCRIPTION
## Summary
- Cast Select `AcceptableValue` when assigning dimension selections so null is not assigned to `string`
- Stub contractor update payload with `as never` in invalidation test (matches other mutation stubs)

## Test plan
- [x] `pnpm type-check` passes